### PR TITLE
updated paypalhttp to v1.0.1 and ran integration tests

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "license": "MIT",
     "homepage": "http://github.com/paypal/PAYOUTS-PHP-SDK/",
     "require": {
-        "paypal/paypalhttp": "~1.0.0"
+        "paypal/paypalhttp": "~1.0.1"
     },
     "authors": [
         {

--- a/lib/PaypalPayoutsSDK/Core/Version.php
+++ b/lib/PaypalPayoutsSDK/Core/Version.php
@@ -4,5 +4,5 @@ namespace PaypalPayoutsSDK\Core;
 
 class Version
 {
-    const VERSION = "1.0.1";
+    const VERSION = "1.0.2";
 }


### PR DESCRIPTION
Upgraded paypalhttp package in composer.json from 1.0.0 to 1.0.1. Ran integration/unit tests

Ran tests with original http package and new version for comparison. The PayoutsItemGetTest may need to be updated, as it failed for both versions of the http


<img width="1792" alt="Screen Shot 2021-09-20 at 12 40 51 PM" src="https://user-images.githubusercontent.com/30755392/134041571-7983dd95-3187-451e-8b40-833e80d667a9.png">


