### PR TITLE
Added $curlCls declaration as a property to add PHP 8.2 compatibility

### DIFF
--- a/lib/PaypalPayoutsSDK/Core/PayPalHttpClient.php
+++ b/lib/PaypalPayoutsSDK/Core/PayPalHttpClient.php
@@ -8,6 +8,7 @@ class PayPalHttpClient extends HttpClient
 {
     private $refreshToken;
     public $authInjector;
+    public $curlCls; // declare property - creation of dynamic property is deprecated on php 8.2
 
     public function __construct(PayPalEnvironment $environment, $refreshToken = NULL)
     {


### PR DESCRIPTION
Hi, I've declared $curlCls as a property in PayPalHttpClient.php to add compatibility of this library with PHP 8.2 and suppress the error "Creation of dynamic property PayPalCheckoutSdk\Core\PayPalHttpClient::$curlCls is deprecated" that appear using PHP 8.2

This will fix this issue: [#24 ](https://github.com/paypal/Payouts-PHP-SDK/issues/24)

Waiting for your merge.
Bye.